### PR TITLE
Bridge No-Codes loadScreen, defaultVariables and custom action event (DEV-1192)

### DIFF
--- a/Editor/QonversionDependencies.xml
+++ b/Editor/QonversionDependencies.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="io.qonversion:sandwich:7.9.0" />
+        <androidPackage spec="io.qonversion:sandwich:7.10.1" />
         <androidPackage spec="com.fasterxml.jackson.core:jackson-databind:2.11.1" />
         <androidPackage spec="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.61" />
     </androidPackages>
     <iosPods>
-      <iosPod name="QonversionSandwich" version="7.9.0" />
+      <iosPod name="QonversionSandwich" version="7.10.1" />
     </iosPods>
 </dependencies>

--- a/Runtime/Android/Plugins/com/qonversion/unitywrapper/NoCodesWrapper.java
+++ b/Runtime/Android/Plugins/com/qonversion/unitywrapper/NoCodesWrapper.java
@@ -15,9 +15,13 @@ import com.unity3d.player.UnityPlayer;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import io.qonversion.sandwich.NoCodesEventListener;
 import io.qonversion.sandwich.NoCodesPurchaseDelegateBridge;
 import io.qonversion.sandwich.NoCodesSandwich;
+import io.qonversion.sandwich.ResultListener;
+import io.qonversion.sandwich.SandwichError;
 
 public class NoCodesWrapper {
     private static final String TAG = "NoCodesWrapper";
@@ -28,6 +32,9 @@ public class NoCodesWrapper {
     private static final String EVENT_ACTION_FINISHED = "OnNoCodesActionFinished";
     private static final String EVENT_FINISHED = "OnNoCodesFinished";
     private static final String EVENT_SCREEN_FAILED_TO_LOAD = "OnNoCodesScreenFailedToLoad";
+    private static final String EVENT_CUSTOM_ACTION = "OnNoCodesCustomAction";
+    private static final String EVENT_SCREEN_LOADED = "OnNoCodesScreenLoaded";
+    private static final String EVENT_SCREEN_LOAD_FAILED = "OnNoCodesScreenLoadFailed";
     private static final String EVENT_PURCHASE = "OnNoCodesPurchase";
     private static final String EVENT_RESTORE = "OnNoCodesRestore";
 
@@ -110,6 +117,27 @@ public class NoCodesWrapper {
         }
 
         noCodesSandwich.showScreen(contextKey, customVariables);
+    }
+
+    public static synchronized void loadScreen(final String contextKey) {
+        if (noCodesSandwich == null) {
+            Log.e(TAG, "NoCodesSandwich is not initialized");
+            return;
+        }
+
+        noCodesSandwich.loadScreen(contextKey, new ResultListener() {
+            @Override
+            public void onSuccess(@NonNull Map<String, ?> data) {
+                sendMessageToUnity(data, EVENT_SCREEN_LOADED);
+            }
+
+            @Override
+            public void onError(@NonNull SandwichError error) {
+                ObjectNode payload = Utils.createErrorNode(error);
+                payload.put("contextKey", contextKey);
+                sendMessageToUnity(payload, EVENT_SCREEN_LOAD_FAILED);
+            }
+        });
     }
 
     public static synchronized void close() {
@@ -207,6 +235,9 @@ public class NoCodesWrapper {
                     break;
                 case ScreenFailedToLoad:
                     methodName = EVENT_SCREEN_FAILED_TO_LOAD;
+                    break;
+                case CustomAction:
+                    methodName = EVENT_CUSTOM_ACTION;
                     break;
                 default:
                     return;

--- a/Runtime/Scripts/NoCodes/Android/NoCodesWrapperAndroid.cs
+++ b/Runtime/Scripts/NoCodes/Android/NoCodesWrapperAndroid.cs
@@ -26,6 +26,11 @@ namespace QonversionUnity
             CallNoCodes("showScreen", contextKey, customVariablesJson ?? "");
         }
 
+        public void LoadScreen(string contextKey)
+        {
+            CallNoCodes("loadScreen", contextKey);
+        }
+
         public void Close()
         {
             CallNoCodes("close");

--- a/Runtime/Scripts/NoCodes/Dto/NoCodesError.cs
+++ b/Runtime/Scripts/NoCodes/Dto/NoCodesError.cs
@@ -85,6 +85,7 @@ namespace QonversionUnity
                 case "RateLimitExceeded": return NoCodesErrorCode.RateLimitExceeded;
                 case "ScreenLoadingFailed": return NoCodesErrorCode.ScreenLoadingFailed;
                 case "SDKInitializationError": return NoCodesErrorCode.SdkInitializationError;
+                case "ClientError": return NoCodesErrorCode.ClientError;
                 default: return NoCodesErrorCode.Unknown;
             }
         }

--- a/Runtime/Scripts/NoCodes/Dto/NoCodesErrorCode.cs
+++ b/Runtime/Scripts/NoCodes/Dto/NoCodesErrorCode.cs
@@ -30,6 +30,7 @@ namespace QonversionUnity
         ProductsLoadingFailed,
         RateLimitExceeded,
         ScreenLoadingFailed,
-        SdkInitializationError
+        SdkInitializationError,
+        ClientError
     }
 }

--- a/Runtime/Scripts/NoCodes/Dto/NoCodesScreen.cs
+++ b/Runtime/Scripts/NoCodes/Dto/NoCodesScreen.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using QonversionUnity.MiniJSON;
+
+namespace QonversionUnity
+{
+    /// <summary>
+    /// Kind of a No-Codes screen default variable — what it was configured as in the builder.
+    /// The set may grow in future backend versions; values this SDK version does not know
+    /// are mapped to <see cref="Unknown"/> instead of failing.
+    /// </summary>
+    public enum NoCodesScreenVariableKind
+    {
+        /// <summary>A Screen Variable authored in the builder's Variables section.</summary>
+        Custom,
+
+        /// <summary>
+        /// A product slot: the variable key is the slot name and the value is the default
+        /// Qonversion product id assigned to it.
+        /// </summary>
+        Product,
+
+        /// <summary>
+        /// The screen's Default Product configured in the builder: the value is
+        /// the Qonversion product id selected by default.
+        /// </summary>
+        SelectedProduct,
+
+        /// <summary>A kind introduced on the backend after this SDK version was released.</summary>
+        Unknown
+    }
+
+    /// <summary>
+    /// A typed default variable of a No-Codes screen, configured in the builder and delivered
+    /// at screen load so it can be read by key. The value keeps its authored type
+    /// (bool / string / number) rather than being coerced to a string.
+    /// </summary>
+    public class NoCodesScreenVariable
+    {
+        /// <summary>What the variable represents — see <see cref="NoCodesScreenVariableKind"/>.</summary>
+        public readonly NoCodesScreenVariableKind Kind;
+
+        /// <summary>
+        /// Variable name it is addressed by (`variable.&lt;key&gt;` in the builder for custom
+        /// variables, the slot name for product slots). May contain spaces.
+        /// </summary>
+        public readonly string Key;
+
+        /// <summary>Authored value type: "boolean", "string" or "number".</summary>
+        public readonly string Type;
+
+        /// <summary>
+        /// The configured default value, preserving its native type (bool, string, long or double).
+        /// Null when no default value was authored.
+        /// </summary>
+        [CanBeNull] public readonly object Value;
+
+        /// <summary>
+        /// The value rendered as a plain string regardless of its native type: "true"/"false"
+        /// for booleans, the string itself, a number without a trailing ".0" when integral,
+        /// or an empty string when no value was authored.
+        /// </summary>
+        public readonly string StringValue;
+
+        public NoCodesScreenVariable(Dictionary<string, object> dict)
+        {
+            Kind = ParseKind(dict.GetString("kind"));
+            Key = dict.GetString("key");
+            Type = dict.GetString("type");
+            dict.TryGetValue("value", out Value);
+            StringValue = dict.GetString("stringValue");
+        }
+
+        private static NoCodesScreenVariableKind ParseKind([CanBeNull] string kind)
+        {
+            switch (kind)
+            {
+                case "custom": return NoCodesScreenVariableKind.Custom;
+                case "product": return NoCodesScreenVariableKind.Product;
+                case "selected_product": return NoCodesScreenVariableKind.SelectedProduct;
+                default: return NoCodesScreenVariableKind.Unknown;
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Kind)}: {Kind}, " +
+                   $"{nameof(Key)}: {Key}, " +
+                   $"{nameof(Type)}: {Type}, " +
+                   $"{nameof(Value)}: {Value}, " +
+                   $"{nameof(StringValue)}: {StringValue}";
+        }
+    }
+
+    /// <summary>
+    /// A loaded No-Codes screen returned from <see cref="INoCodes.LoadScreen"/>.
+    ///
+    /// Exposes the screen identifiers and the typed default variables configured in the builder —
+    /// the screen content stays internal, as rendering remains the SDK's job via
+    /// <see cref="INoCodes.ShowScreen"/>.
+    /// </summary>
+    public class NoCodesScreen
+    {
+        /// <summary>Identifier of the screen.</summary>
+        public readonly string Id;
+
+        /// <summary>The context key of the screen set in the No-Codes builder.</summary>
+        public readonly string ContextKey;
+
+        /// <summary>
+        /// The Qonversion product id selected by default when the screen opens (the builder's
+        /// Default Product), or null when none is configured.
+        /// </summary>
+        [CanBeNull] public readonly string DefaultSelectedProductId;
+
+        /// <summary>
+        /// Typed default variables of the screen configured in the builder: authored custom
+        /// variables and product slots. Read them by <see cref="NoCodesScreenVariable.Key"/> (may be empty).
+        /// </summary>
+        public readonly List<NoCodesScreenVariable> DefaultVariables = new List<NoCodesScreenVariable>();
+
+        public NoCodesScreen(Dictionary<string, object> dict)
+        {
+            Id = dict.GetString("id");
+            ContextKey = dict.GetString("contextKey");
+            DefaultSelectedProductId = dict.TryGetValue("defaultSelectedProductId", out object productId)
+                ? productId as string
+                : null;
+
+            if (dict.TryGetValue("defaultVariables", out object variablesValue) && variablesValue is List<object> rawVariables)
+            {
+                foreach (object rawVariable in rawVariables)
+                {
+                    if (rawVariable is Dictionary<string, object> variableDict)
+                    {
+                        DefaultVariables.Add(new NoCodesScreenVariable(variableDict));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the default variable configured under the given key, or null when the screen
+        /// has no variable with that exact (case-sensitive) key.
+        ///
+        /// Keys are only unique within a kind — a custom variable and a product slot may share
+        /// a name — so pass <paramref name="kind"/> to disambiguate; without it the first match
+        /// in payload order (custom variables, then product slots, then the selected product)
+        /// is returned.
+        ///
+        /// For the default selected product prefer <see cref="DefaultSelectedProductId"/> — it needs no key.
+        /// </summary>
+        [CanBeNull]
+        public NoCodesScreenVariable DefaultVariable(string key, NoCodesScreenVariableKind? kind = null)
+        {
+            foreach (NoCodesScreenVariable variable in DefaultVariables)
+            {
+                if (variable.Key == key && (kind == null || variable.Kind == kind))
+                {
+                    return variable;
+                }
+            }
+
+            return null;
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Id)}: {Id}, " +
+                   $"{nameof(ContextKey)}: {ContextKey}, " +
+                   $"{nameof(DefaultSelectedProductId)}: {DefaultSelectedProductId}, " +
+                   $"{nameof(DefaultVariables)}: {string.Join("; ", DefaultVariables)}";
+        }
+    }
+}

--- a/Runtime/Scripts/NoCodes/Dto/NoCodesScreen.cs.meta
+++ b/Runtime/Scripts/NoCodes/Dto/NoCodesScreen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9ac2daf1b3c146a4a8f458088984dd5c

--- a/Runtime/Scripts/NoCodes/INoCodes.cs
+++ b/Runtime/Scripts/NoCodes/INoCodes.cs
@@ -25,6 +25,19 @@ namespace QonversionUnity
         void ShowScreen(string contextKey, [CanBeNull] System.Collections.Generic.Dictionary<string, string> customVariables = null);
 
         /// <summary>
+        /// Load a No-Code screen (from cache or network) without presenting it, so you can decide
+        /// whether to present it or show your own fallback UI before any SDK screen appears.
+        /// Present the screen with <see cref="ShowScreen"/> — the loaded content is served from cache.
+        ///
+        /// The returned <see cref="NoCodesScreen"/> exposes the typed default variables configured
+        /// in the builder and the default selected product id.
+        /// </summary>
+        /// <param name="contextKey">The context key of the screen to load.</param>
+        /// <param name="onSuccess">Called with the loaded screen data.</param>
+        /// <param name="onError">Called when loading fails.</param>
+        void LoadScreen(string contextKey, System.Action<NoCodesScreen> onSuccess, System.Action<NoCodesError> onError);
+
+        /// <summary>
         /// Close the current opened No-Code screen.
         /// </summary>
         void Close();

--- a/Runtime/Scripts/NoCodes/Internal/INoCodesWrapper.cs
+++ b/Runtime/Scripts/NoCodes/Internal/INoCodesWrapper.cs
@@ -8,6 +8,7 @@ namespace QonversionUnity
         void SetDelegate();
         void SetScreenPresentationConfig(string configJson, [CanBeNull] string contextKey);
         void ShowScreen(string contextKey, [CanBeNull] string customVariablesJson);
+        void LoadScreen(string contextKey);
         void Close();
         void SetLocale([CanBeNull] string locale);
         void SetTheme(string theme);

--- a/Runtime/Scripts/NoCodes/Internal/NoCodesInternal.cs
+++ b/Runtime/Scripts/NoCodes/Internal/NoCodesInternal.cs
@@ -12,6 +12,17 @@ namespace QonversionUnity
         private NoCodesPurchaseDelegate _purchaseDelegate;
         private NoCodesConfig _config;
 
+        private struct LoadScreenCallbacks
+        {
+            public System.Action<NoCodesScreen> OnSuccess;
+            public System.Action<NoCodesError> OnError;
+        }
+
+        // Load requests are correlated by contextKey: both the success payload (the screen map)
+        // and the native failure payload carry it.
+        private readonly System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<LoadScreenCallbacks>> _loadScreenCallbacks =
+            new System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<LoadScreenCallbacks>>();
+
         public static NoCodesInternal CreateInstance(NoCodesConfig config)
         {
             GameObject go = new GameObject(GameObjectName);
@@ -56,6 +67,20 @@ namespace QonversionUnity
             INoCodesWrapper wrapper = GetNativeWrapper();
             string customVariablesJson = customVariables != null ? MiniJSON.Json.Serialize(customVariables) : null;
             wrapper.ShowScreen(contextKey, customVariablesJson);
+        }
+
+        public void LoadScreen(string contextKey, System.Action<NoCodesScreen> onSuccess, System.Action<NoCodesError> onError)
+        {
+            if (!_loadScreenCallbacks.TryGetValue(contextKey, out var callbacks))
+            {
+                callbacks = new System.Collections.Generic.List<LoadScreenCallbacks>();
+                _loadScreenCallbacks[contextKey] = callbacks;
+            }
+
+            callbacks.Add(new LoadScreenCallbacks { OnSuccess = onSuccess, OnError = onError });
+
+            INoCodesWrapper wrapper = GetNativeWrapper();
+            wrapper.LoadScreen(contextKey);
         }
 
         public void Close()
@@ -197,6 +222,49 @@ namespace QonversionUnity
             {
                 _noCodesDelegate.OnScreenFailedToLoad(error);
             }
+        }
+
+        private void OnNoCodesCustomAction(string jsonString)
+        {
+            if (!(_noCodesDelegate is NoCodesCustomActionDelegate customActionDelegate)) return;
+
+            string value = NoCodesMapper.CustomActionValueFromJson(jsonString);
+            customActionDelegate.OnCustomAction(value);
+        }
+
+        // Called from native with the loaded screen data
+        private void OnNoCodesScreenLoaded(string jsonString)
+        {
+            NoCodesScreen screen = NoCodesMapper.ScreenFromJson(jsonString);
+            if (screen == null) return;
+
+            foreach (LoadScreenCallbacks callbacks in TakeLoadScreenCallbacks(screen.ContextKey))
+            {
+                callbacks.OnSuccess?.Invoke(screen);
+            }
+        }
+
+        // Called from native when loading a screen failed; payload: { contextKey, error }
+        private void OnNoCodesScreenLoadFailed(string jsonString)
+        {
+            string contextKey = NoCodesMapper.ContextKeyFromJson(jsonString);
+            NoCodesError error = NoCodesMapper.LoadScreenErrorFromJson(jsonString);
+
+            foreach (LoadScreenCallbacks callbacks in TakeLoadScreenCallbacks(contextKey))
+            {
+                callbacks.OnError?.Invoke(error);
+            }
+        }
+
+        private System.Collections.Generic.List<LoadScreenCallbacks> TakeLoadScreenCallbacks(string contextKey)
+        {
+            if (contextKey == null || !_loadScreenCallbacks.TryGetValue(contextKey, out var callbacks))
+            {
+                return new System.Collections.Generic.List<LoadScreenCallbacks>();
+            }
+
+            _loadScreenCallbacks.Remove(contextKey);
+            return callbacks;
         }
 
         // Called from native for purchase delegate

--- a/Runtime/Scripts/NoCodes/Internal/NoCodesInternal.cs
+++ b/Runtime/Scripts/NoCodes/Internal/NoCodesInternal.cs
@@ -71,6 +71,15 @@ namespace QonversionUnity
 
         public void LoadScreen(string contextKey, System.Action<NoCodesScreen> onSuccess, System.Action<NoCodesError> onError)
         {
+            INoCodesWrapper wrapper = GetNativeWrapper();
+            if (wrapper is NoCodesWrapperNoop)
+            {
+                // The noop wrapper never sends anything back — fail synchronously
+                // instead of leaving the request pending forever.
+                onError?.Invoke(NoCodesMapper.UnsupportedPlatformError());
+                return;
+            }
+
             if (!_loadScreenCallbacks.TryGetValue(contextKey, out var callbacks))
             {
                 callbacks = new System.Collections.Generic.List<LoadScreenCallbacks>();
@@ -79,7 +88,6 @@ namespace QonversionUnity
 
             callbacks.Add(new LoadScreenCallbacks { OnSuccess = onSuccess, OnError = onError });
 
-            INoCodesWrapper wrapper = GetNativeWrapper();
             wrapper.LoadScreen(contextKey);
         }
 
@@ -236,7 +244,18 @@ namespace QonversionUnity
         private void OnNoCodesScreenLoaded(string jsonString)
         {
             NoCodesScreen screen = NoCodesMapper.ScreenFromJson(jsonString);
-            if (screen == null) return;
+            if (screen == null)
+            {
+                // Don't leave the request pending on an unparseable payload — fail the
+                // callbacks the payload's contextKey still lets us correlate.
+                string contextKey = NoCodesMapper.ContextKeyFromJson(jsonString);
+                NoCodesError parseError = NoCodesMapper.ScreenParsingError();
+                foreach (LoadScreenCallbacks callbacks in TakeLoadScreenCallbacks(contextKey))
+                {
+                    callbacks.OnError?.Invoke(parseError);
+                }
+                return;
+            }
 
             foreach (LoadScreenCallbacks callbacks in TakeLoadScreenCallbacks(screen.ContextKey))
             {

--- a/Runtime/Scripts/NoCodes/Internal/NoCodesMapper.cs
+++ b/Runtime/Scripts/NoCodes/Internal/NoCodesMapper.cs
@@ -77,6 +77,26 @@ namespace QonversionUnity
             return dict.GetString("contextKey");
         }
 
+        internal static NoCodesError ScreenParsingError()
+        {
+            return new NoCodesError(new Dictionary<string, object>
+            {
+                { "code", "Deserialization" },
+                { "description", "Failed to parse the loaded No-Code screen" },
+                { "additionalMessage", "Native payload parsing failed." }
+            });
+        }
+
+        internal static NoCodesError UnsupportedPlatformError()
+        {
+            return new NoCodesError(new Dictionary<string, object>
+            {
+                { "code", "Unknown" },
+                { "description", "No-Codes is not supported on this platform" },
+                { "additionalMessage", "" }
+            });
+        }
+
         internal static NoCodesError LoadScreenErrorFromJson(string jsonStr)
         {
             if (Json.Deserialize(jsonStr) is Dictionary<string, object> dict &&

--- a/Runtime/Scripts/NoCodes/Internal/NoCodesMapper.cs
+++ b/Runtime/Scripts/NoCodes/Internal/NoCodesMapper.cs
@@ -52,7 +52,17 @@ namespace QonversionUnity
                 return null;
             }
 
-            return new NoCodesScreen(screenDict);
+            try
+            {
+                return new NoCodesScreen(screenDict);
+            }
+            catch (System.Exception e)
+            {
+                // An anomalous payload (e.g. null field values) must fail the pending
+                // LoadScreen callbacks, not escape into the UnitySendMessage handler.
+                Debug.LogError("Could not map NoCodes screen: " + e.Message);
+                return null;
+            }
         }
 
         internal static string CustomActionValueFromJson(string jsonStr)

--- a/Runtime/Scripts/NoCodes/Internal/NoCodesMapper.cs
+++ b/Runtime/Scripts/NoCodes/Internal/NoCodesMapper.cs
@@ -44,6 +44,58 @@ namespace QonversionUnity
         }
 
         [CanBeNull]
+        internal static NoCodesScreen ScreenFromJson(string jsonStr)
+        {
+            if (!(Json.Deserialize(jsonStr) is Dictionary<string, object> screenDict))
+            {
+                Debug.LogError("Could not parse NoCodes screen");
+                return null;
+            }
+
+            return new NoCodesScreen(screenDict);
+        }
+
+        internal static string CustomActionValueFromJson(string jsonStr)
+        {
+            if (!(Json.Deserialize(jsonStr) is Dictionary<string, object> dict))
+            {
+                Debug.LogError("Could not parse NoCodes custom action");
+                return "";
+            }
+
+            return dict.GetString("value");
+        }
+
+        [CanBeNull]
+        internal static string ContextKeyFromJson(string jsonStr)
+        {
+            if (!(Json.Deserialize(jsonStr) is Dictionary<string, object> dict))
+            {
+                return null;
+            }
+
+            return dict.GetString("contextKey");
+        }
+
+        internal static NoCodesError LoadScreenErrorFromJson(string jsonStr)
+        {
+            if (Json.Deserialize(jsonStr) is Dictionary<string, object> dict &&
+                dict.TryGetValue("error", out object errorValue) &&
+                errorValue is Dictionary<string, object> errorDict)
+            {
+                return new NoCodesError(errorDict);
+            }
+
+            Debug.LogError("Could not parse NoCodes screen loading error");
+            return new NoCodesError(new Dictionary<string, object>
+            {
+                { "code", "Unknown" },
+                { "description", "Failed to load No-Code screen" },
+                { "additionalMessage", "Native error parsing failed." }
+            });
+        }
+
+        [CanBeNull]
         internal static Product ProductFromJson(string jsonStr)
         {
             if (!(Json.Deserialize(jsonStr) is Dictionary<string, object> productDict))

--- a/Runtime/Scripts/NoCodes/Internal/NoCodesWrapperNoop.cs
+++ b/Runtime/Scripts/NoCodes/Internal/NoCodesWrapperNoop.cs
@@ -27,6 +27,11 @@ namespace QonversionUnity
             Debug.Log($"NoCodes.ShowScreen({contextKey}) called on unsupported platform.");
         }
 
+        public void LoadScreen(string contextKey)
+        {
+            Debug.Log($"NoCodes.LoadScreen({contextKey}) called on unsupported platform.");
+        }
+
         public void Close()
         {
             // No-op

--- a/Runtime/Scripts/NoCodes/NoCodesCustomActionDelegate.cs
+++ b/Runtime/Scripts/NoCodes/NoCodesCustomActionDelegate.cs
@@ -1,0 +1,22 @@
+namespace QonversionUnity
+{
+    /// <summary>
+    /// Optional companion to <see cref="NoCodesDelegate"/> for receiving custom actions
+    /// configured in the No-Codes builder.
+    ///
+    /// Implement this interface on the same class as your <see cref="NoCodesDelegate"/> —
+    /// it is a separate interface (instead of a new <see cref="NoCodesDelegate"/> method)
+    /// to keep existing delegate implementations source-compatible.
+    /// </summary>
+    public interface NoCodesCustomActionDelegate
+    {
+        /// <summary>
+        /// Called when a custom action configured in the builder is triggered on the screen.
+        /// The No-Codes SDK does not execute anything itself — handle the value in your app code.
+        /// The screen stays open; close it using <see cref="INoCodes.Close"/> if needed.
+        /// </summary>
+        /// <param name="value">The string value configured for the custom action in the builder,
+        /// or an empty string if no value was configured.</param>
+        void OnCustomAction(string value);
+    }
+}

--- a/Runtime/Scripts/NoCodes/NoCodesCustomActionDelegate.cs.meta
+++ b/Runtime/Scripts/NoCodes/NoCodesCustomActionDelegate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 67063ead83f74bdfbf1d68ebdf1cc07f

--- a/Runtime/Scripts/NoCodes/iOS/NoCodesWrapperIOS.cs
+++ b/Runtime/Scripts/NoCodes/iOS/NoCodesWrapperIOS.cs
@@ -20,6 +20,9 @@ namespace QonversionUnity
         private static extern void _showNoCodesScreen(string contextKey, string customVariablesJson);
 
         [DllImport("__Internal")]
+        private static extern void _loadNoCodesScreen(string contextKey);
+
+        [DllImport("__Internal")]
         private static extern void _closeNoCodes();
 
         [DllImport("__Internal")]
@@ -69,6 +72,13 @@ namespace QonversionUnity
         {
 #if UNITY_IOS
             _showNoCodesScreen(contextKey, customVariablesJson ?? "");
+#endif
+        }
+
+        public void LoadScreen(string contextKey)
+        {
+#if UNITY_IOS
+            _loadNoCodesScreen(contextKey);
 #endif
         }
 

--- a/Runtime/iOS/Plugins/NoCodes/NoCodesBridge.m
+++ b/Runtime/iOS/Plugins/NoCodes/NoCodesBridge.m
@@ -50,6 +50,11 @@ void _showNoCodesScreen(const char* contextKey, const char* customVariablesJson)
     [noCodesBridge showScreen:contextKeyStr customVariables:customVariables];
 }
 
+void _loadNoCodesScreen(const char* contextKey) {
+    NSString *contextKeyStr = [UtilityBridge convertCStringToNSString:contextKey];
+    [noCodesBridge loadScreen:contextKeyStr];
+}
+
 void _closeNoCodes() {
     [noCodesBridge close];
 }

--- a/Runtime/iOS/Plugins/NoCodes/QNUNoCodesDelegate.h
+++ b/Runtime/iOS/Plugins/NoCodes/QNUNoCodesDelegate.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setDelegate;
 - (void)setScreenPresentationConfig:(NSDictionary *)config contextKey:(NSString * _Nullable)contextKey;
 - (void)showScreen:(NSString *)contextKey customVariables:(NSDictionary<NSString *, NSString *> * _Nullable)customVariables;
+- (void)loadScreen:(NSString *)contextKey;
 - (void)close;
 - (void)setLocale:(NSString * _Nullable)locale;
 - (void)setTheme:(NSString * _Nullable)theme;

--- a/Runtime/iOS/Plugins/NoCodes/QNUNoCodesDelegate.m
+++ b/Runtime/iOS/Plugins/NoCodes/QNUNoCodesDelegate.m
@@ -12,6 +12,9 @@ static NSString *const kEventActionFailed = @"OnNoCodesActionFailed";
 static NSString *const kEventActionFinished = @"OnNoCodesActionFinished";
 static NSString *const kEventFinished = @"OnNoCodesFinished";
 static NSString *const kEventScreenFailedToLoad = @"OnNoCodesScreenFailedToLoad";
+static NSString *const kEventCustomAction = @"OnNoCodesCustomAction";
+static NSString *const kEventScreenLoaded = @"OnNoCodesScreenLoaded";
+static NSString *const kEventScreenLoadFailed = @"OnNoCodesScreenLoadFailed";
 static NSString *const kEventPurchase = @"OnNoCodesPurchase";
 static NSString *const kEventRestore = @"OnNoCodesRestore";
 
@@ -37,7 +40,8 @@ char* noCodesListenerName = nil;
             @"nocodes_action_failed": kEventActionFailed,
             @"nocodes_action_finished": kEventActionFinished,
             @"nocodes_finished": kEventFinished,
-            @"nocodes_screen_failed_to_load": kEventScreenFailedToLoad
+            @"nocodes_screen_failed_to_load": kEventScreenFailedToLoad,
+            @"nocodes_custom_action": kEventCustomAction
         };
     }
     
@@ -66,6 +70,18 @@ char* noCodesListenerName = nil;
 
 - (void)showScreen:(NSString *)contextKey customVariables:(NSDictionary<NSString *, NSString *> * _Nullable)customVariables {
     [self.noCodesSandwich showScreen:contextKey customVariables:customVariables];
+}
+
+- (void)loadScreen:(NSString *)contextKey {
+    [self.noCodesSandwich loadScreen:contextKey completion:^(NSDictionary<NSString *,id> * _Nullable result, SandwichError * _Nullable error) {
+        if (error) {
+            NSMutableDictionary *payload = [[UtilityBridge serializeSandwichError:error] mutableCopy];
+            payload[@"contextKey"] = contextKey;
+            [UtilityBridge sendUnityMessage:payload toMethod:kEventScreenLoadFailed unityListener:noCodesListenerName];
+        } else {
+            [UtilityBridge sendUnityMessage:result ?: @{} toMethod:kEventScreenLoaded unityListener:noCodesListenerName];
+        }
+    }];
 }
 
 - (void)close {


### PR DESCRIPTION
Brings the No-Codes API from sandwich **7.10.1** (native iOS 6.13.0 / Android nocodes 1.10.0) into the Unity layer.

[DEV-1192](https://linear.app/qonversion/issue/DEV-1192/unity-no-codes-loadscreen-defaultvariables-and-custom-action-event)

## Changes
- Sandwich bump 7.9.0 → **7.10.1** (EDM4U `QonversionDependencies.xml`, android + iOS pods).
- `NoCodes.LoadScreen(contextKey, onSuccess, onError)` — load-before-present; `NoCodesScreen` exposes `Id`, `ContextKey`, `DefaultSelectedProductId` and typed `DefaultVariables` (`Kind/Key/Type/Value/StringValue`) + `DefaultVariable(key, kind)` lookup mirroring the native SDKs. Presenting stays on `ShowScreen` (served from cache). Requests are correlated by `contextKey`: the success payload (screen map) carries it natively, and both native failure payloads attach it next to the standard `{error: {...}}` envelope (`serializeSandwichError` / `Utils.createErrorNode`).
- Custom builder actions surface via the new **optional `NoCodesCustomActionDelegate`** interface (dispatched with an `is`-check on the existing delegate). A separate interface instead of a new `NoCodesDelegate` method because the package targets **Unity 2018.3**, which has no C# default interface methods — adding a member would break every existing implementor.
- New Unity messages `OnNoCodesScreenLoaded` / `OnNoCodesScreenLoadFailed` / `OnNoCodesCustomAction` wired in both natives (`QNUNoCodesDelegate`, `NoCodesWrapper.java`).

## Verification
- Full `Runtime/**` C# tree compiled with `csc` against Unity 6000.3.3f1 `UnityEngine` assemblies — **0 errors**.
- ObjC/Java sides follow the existing bridge patterns verbatim (`UtilityBridge.sendUnityMessage`, `MessageSender`); the repo has no compile harness for them (no sample project, CI has no build step).
- `.meta` files generated for the two new C# files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEJXqfVNxqoUcKXhSPhWn