### PR TITLE
chore: deprecate public Offerings API

### DIFF
--- a/Runtime/Scripts/IQonversion.cs
+++ b/Runtime/Scripts/IQonversion.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
@@ -86,8 +87,9 @@ namespace QonversionUnity
         /// Offerings allow changing the products offered remotely without releasing app updates.
         /// </summary>
         /// <param name="callback">Callback that will be called when response is received.</param>
-        /// <see href="https://qonversion.io/docs/offerings">Offerings</see>
+        /// <see href="https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs">Migrate Offerings to Remote Configs</see>
         /// <see href="https://qonversion.io/docs/product-center">Product Center</see>
+        [Obsolete("Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs")]
         public void Offerings(Qonversion.OnOfferingsReceived callback);
 
         /// <summary>

--- a/Runtime/Scripts/Internal/QonversionInternal.cs
+++ b/Runtime/Scripts/Internal/QonversionInternal.cs
@@ -167,6 +167,7 @@ namespace QonversionUnity
             instance.Products(OnProductsMethodName);
         }
 
+        [Obsolete("Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs")]
         public void Offerings(Qonversion.OnOfferingsReceived callback)
         {
             OfferingsCallbacks.Add(callback);


### PR DESCRIPTION
## Deprecate the public Offerings API

Offerings is a legacy Qonversion feature that has been superseded by **Remote Configs**. This PR marks the public Offerings entry point as deprecated so integrators are steered toward the supported replacement.

### What changed
- `[Obsolete]` on the public interface method `IQonversion.Offerings(Qonversion.OnOfferingsReceived callback)` (`Runtime/Scripts/IQonversion.cs`).
- `[Obsolete]` on the implementation `QonversionInternal.Offerings(...)` (`Runtime/Scripts/Internal/QonversionInternal.cs`).
- XML-doc `<see href>` updated from the old Offerings docs URL to the migration guide.

### What did NOT change
- **No behavior change.** The method still works exactly as before; callers only get a compile-time deprecation warning.
- DTOs (`Offerings`, `Offering`) are intentionally left untouched — they remain part of the response types.
- No version bump, CHANGELOG, or `package.json` changes.
- No internal SDK calls the deprecated method, so no `#pragma warning disable 618` was needed.

### Migration
Manage paywall products with Remote Configs instead:
https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs

### Related
- documentation_mintlify#100
- dash-mono#571

> Do not merge — deprecation coordination PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
