### PR TITLE
DEV-1215: expose purchaseOptionId on Product

### DIFF
--- a/Editor/QonversionDependencies.xml
+++ b/Editor/QonversionDependencies.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="io.qonversion:sandwich:7.10.1" />
+        <androidPackage spec="io.qonversion:sandwich:7.11.0" />
         <androidPackage spec="com.fasterxml.jackson.core:jackson-databind:2.11.1" />
         <androidPackage spec="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.61" />
     </androidPackages>
     <iosPods>
-      <iosPod name="QonversionSandwich" version="7.10.1" />
+      <iosPod name="QonversionSandwich" version="7.11.0" />
     </iosPods>
 </dependencies>

--- a/Runtime/Scripts/Dto/Product.cs
+++ b/Runtime/Scripts/Dto/Product.cs
@@ -198,6 +198,7 @@ namespace QonversionUnity
             return $"{nameof(QonversionId)}: {QonversionId}, " +
                    $"{nameof(StoreId)}: {StoreId}, " +
                    $"{nameof(BasePlanId)}: {BasePlanId}, " +
+                   $"{nameof(PurchaseOptionId)}: {PurchaseOptionId}, " +
                    $"{nameof(Type)}: {Type}, " +
                    $"{nameof(SubscriptionPeriod)}: {SubscriptionPeriod}, " +
                    $"{nameof(TrialPeriod)}: {TrialPeriod}, " +

--- a/Runtime/Scripts/Dto/Product.cs
+++ b/Runtime/Scripts/Dto/Product.cs
@@ -15,8 +15,13 @@ namespace QonversionUnity
         [Tooltip("Create Products: (https://qonversion.io/docs/create-products")]
         [CanBeNull] public readonly string StoreId;
 
-        /// Identifier of the base plan for Google product.
-        [CanBeNull] public readonly string BasePlanId; 
+        /// Identifier of the base plan for a Google Play subscription product.
+        /// Android only. Null for one-time products - use <see cref="PurchaseOptionId"/> for those.
+        [CanBeNull] public readonly string BasePlanId;
+
+        /// Identifier of the Google Play purchase option for a one-time (in-app) product.
+        /// Android only. Null for subscription products - use <see cref="BasePlanId"/> for those.
+        [CanBeNull] public readonly string PurchaseOptionId;
 
         /// Google Play Store details of this product.
         /// Android only. Null for iOS, or if the product was not found.
@@ -68,6 +73,7 @@ namespace QonversionUnity
             if (dict.TryGetValue("id", out object value)) QonversionId = value as string;
             if (dict.TryGetValue("storeId", out value)) StoreId = value as string;
             if (dict.TryGetValue("basePlanId", out value)) BasePlanId = value as string;
+            if (dict.TryGetValue("purchaseOptionId", out value)) PurchaseOptionId = value as string;
             if (dict.TryGetValue("offeringId", out value)) OfferingId = value as string;
 
             if (dict.TryGetValue("subscriptionPeriod", out value) && value is Dictionary<string, object> subscriptionPeriod)

--- a/Runtime/Scripts/Dto/ProductStoreDetails/ProductStoreDetails.cs
+++ b/Runtime/Scripts/Dto/ProductStoreDetails/ProductStoreDetails.cs
@@ -140,6 +140,7 @@ namespace QonversionUnity
             }
 
             return $"{nameof(BasePlanId)}: {BasePlanId}, " +
+                   $"{nameof(PurchaseOptionId)}: {PurchaseOptionId}, " +
                    $"{nameof(ProductId)}: {ProductId}, " +
                    $"{nameof(Name)}: {Name}, " +
                    $"{nameof(Title)}: {Title}, " +

--- a/Runtime/Scripts/Dto/ProductStoreDetails/ProductStoreDetails.cs
+++ b/Runtime/Scripts/Dto/ProductStoreDetails/ProductStoreDetails.cs
@@ -10,9 +10,13 @@ namespace QonversionUnity
     /// </summary>
     public class ProductStoreDetails
     {
-        /// Identifier of the base plan to which these details relate.
-        /// Null for in-app products.
+        /// Identifier of the base plan for a Google Play subscription product.
+        /// Null for one-time products - use <see cref="PurchaseOptionId"/> for those.
         public readonly string BasePlanId;
+
+        /// Identifier of the Google Play purchase option for a one-time (in-app) product.
+        /// Null for subscription products - use <see cref="BasePlanId"/> for those.
+        public readonly string PurchaseOptionId;
 
         /// Identifier of the subscription or the in-app product.
         public readonly string ProductId;
@@ -82,6 +86,7 @@ namespace QonversionUnity
         {
             if (dict.TryGetValue("productId", out object value)) ProductId = value as string;
             if (dict.TryGetValue("basePlanId", out value)) BasePlanId = value as string;
+            if (dict.TryGetValue("purchaseOptionId", out value)) PurchaseOptionId = value as string;
             if (dict.TryGetValue("name", out value)) Name = value as string;
             if (dict.TryGetValue("title", out value)) Title = value as string;
             if (dict.TryGetValue("description", out value)) Description = value as string;


### PR DESCRIPTION
Issue: [DEV-1215](https://linear.app/qonversion/issue/DEV-1215)

Add a dedicated `purchaseOptionId` field for one-time products, parsed from the native bridge map, mirroring `basePlanId`. `basePlanId` now carries the subscription base plan only (null for one-time); `purchaseOptionId` carries the one-time purchase option (null for subscriptions).

Runtime chain: native (android-sdk #847) → sandwich (#352, must emit the key) → this wrapper. Wrapper code is self-contained (C#); the value populates once the bundled sandwich emits `purchaseOptionId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)