### PR TITLE
Release 9.8.0

### DIFF
--- a/Editor/QonversionDependencies.xml
+++ b/Editor/QonversionDependencies.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="io.qonversion:sandwich:7.10.1" />
+        <androidPackage spec="io.qonversion:sandwich:7.11.0" />
         <androidPackage spec="com.fasterxml.jackson.core:jackson-databind:2.11.1" />
         <androidPackage spec="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.61" />
     </androidPackages>
     <iosPods>
-      <iosPod name="QonversionSandwich" version="7.10.1" />
+      <iosPod name="QonversionSandwich" version="7.11.0" />
     </iosPods>
 </dependencies>

--- a/Runtime/Scripts/Dto/Product.cs
+++ b/Runtime/Scripts/Dto/Product.cs
@@ -198,6 +198,7 @@ namespace QonversionUnity
             return $"{nameof(QonversionId)}: {QonversionId}, " +
                    $"{nameof(StoreId)}: {StoreId}, " +
                    $"{nameof(BasePlanId)}: {BasePlanId}, " +
+                   $"{nameof(PurchaseOptionId)}: {PurchaseOptionId}, " +
                    $"{nameof(Type)}: {Type}, " +
                    $"{nameof(SubscriptionPeriod)}: {SubscriptionPeriod}, " +
                    $"{nameof(TrialPeriod)}: {TrialPeriod}, " +

--- a/Runtime/Scripts/Dto/Product.cs
+++ b/Runtime/Scripts/Dto/Product.cs
@@ -15,8 +15,13 @@ namespace QonversionUnity
         [Tooltip("Create Products: (https://qonversion.io/docs/create-products")]
         [CanBeNull] public readonly string StoreId;
 
-        /// Identifier of the base plan for Google product.
-        [CanBeNull] public readonly string BasePlanId; 
+        /// Identifier of the base plan for a Google Play subscription product.
+        /// Android only. Null for one-time products - use <see cref="PurchaseOptionId"/> for those.
+        [CanBeNull] public readonly string BasePlanId;
+
+        /// Identifier of the Google Play purchase option for a one-time (in-app) product.
+        /// Android only. Null for subscription products - use <see cref="BasePlanId"/> for those.
+        [CanBeNull] public readonly string PurchaseOptionId;
 
         /// Google Play Store details of this product.
         /// Android only. Null for iOS, or if the product was not found.
@@ -68,6 +73,7 @@ namespace QonversionUnity
             if (dict.TryGetValue("id", out object value)) QonversionId = value as string;
             if (dict.TryGetValue("storeId", out value)) StoreId = value as string;
             if (dict.TryGetValue("basePlanId", out value)) BasePlanId = value as string;
+            if (dict.TryGetValue("purchaseOptionId", out value)) PurchaseOptionId = value as string;
             if (dict.TryGetValue("offeringId", out value)) OfferingId = value as string;
 
             if (dict.TryGetValue("subscriptionPeriod", out value) && value is Dictionary<string, object> subscriptionPeriod)

--- a/Runtime/Scripts/Dto/ProductStoreDetails/ProductStoreDetails.cs
+++ b/Runtime/Scripts/Dto/ProductStoreDetails/ProductStoreDetails.cs
@@ -140,6 +140,7 @@ namespace QonversionUnity
             }
 
             return $"{nameof(BasePlanId)}: {BasePlanId}, " +
+                   $"{nameof(PurchaseOptionId)}: {PurchaseOptionId}, " +
                    $"{nameof(ProductId)}: {ProductId}, " +
                    $"{nameof(Name)}: {Name}, " +
                    $"{nameof(Title)}: {Title}, " +

--- a/Runtime/Scripts/Dto/ProductStoreDetails/ProductStoreDetails.cs
+++ b/Runtime/Scripts/Dto/ProductStoreDetails/ProductStoreDetails.cs
@@ -10,9 +10,13 @@ namespace QonversionUnity
     /// </summary>
     public class ProductStoreDetails
     {
-        /// Identifier of the base plan to which these details relate.
-        /// Null for in-app products.
+        /// Identifier of the base plan for a Google Play subscription product.
+        /// Null for one-time products - use <see cref="PurchaseOptionId"/> for those.
         public readonly string BasePlanId;
+
+        /// Identifier of the Google Play purchase option for a one-time (in-app) product.
+        /// Null for subscription products - use <see cref="BasePlanId"/> for those.
+        public readonly string PurchaseOptionId;
 
         /// Identifier of the subscription or the in-app product.
         public readonly string ProductId;
@@ -82,6 +86,7 @@ namespace QonversionUnity
         {
             if (dict.TryGetValue("productId", out object value)) ProductId = value as string;
             if (dict.TryGetValue("basePlanId", out value)) BasePlanId = value as string;
+            if (dict.TryGetValue("purchaseOptionId", out value)) PurchaseOptionId = value as string;
             if (dict.TryGetValue("name", out value)) Name = value as string;
             if (dict.TryGetValue("title", out value)) Title = value as string;
             if (dict.TryGetValue("description", out value)) Description = value as string;

--- a/Runtime/Scripts/IQonversion.cs
+++ b/Runtime/Scripts/IQonversion.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
@@ -86,8 +87,9 @@ namespace QonversionUnity
         /// Offerings allow changing the products offered remotely without releasing app updates.
         /// </summary>
         /// <param name="callback">Callback that will be called when response is received.</param>
-        /// <see href="https://qonversion.io/docs/offerings">Offerings</see>
+        /// <see href="https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs">Migrate Offerings to Remote Configs</see>
         /// <see href="https://qonversion.io/docs/product-center">Product Center</see>
+        [Obsolete("Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs")]
         public void Offerings(Qonversion.OnOfferingsReceived callback);
 
         /// <summary>

--- a/Runtime/Scripts/Internal/QonversionInternal.cs
+++ b/Runtime/Scripts/Internal/QonversionInternal.cs
@@ -28,7 +28,7 @@ namespace QonversionUnity
         private const string OnIsFallbackFileAccessibleMethodName = "OnIsFallbackFileAccessible";
         private const string OnPromotionalOfferMethodName = "OnPromotionalOffer";
 
-        private const string SdkVersion = "9.7.0";
+        private const string SdkVersion = "9.8.0";
         private const string SdkSource = "unity";
 
         private const string DefaultRemoteConfigContextKey = "";

--- a/Runtime/Scripts/Internal/QonversionInternal.cs
+++ b/Runtime/Scripts/Internal/QonversionInternal.cs
@@ -167,6 +167,7 @@ namespace QonversionUnity
             instance.Products(OnProductsMethodName);
         }
 
+        [Obsolete("Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs")]
         public void Offerings(Qonversion.OnOfferingsReceived callback)
         {
             OfferingsCallbacks.Add(callback);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.qonversion.unity",
 	"displayName": "Qonversion",
-	"version": "9.7.0",
+	"version": "9.8.0",
 	"unity": "2018.3",
 	"description": "Empower your mobile app marketing and product decisions with precise subscription data.",
 	"author": {


### PR DESCRIPTION
Release PR

<!-- release-notes:start -->
## What's New

— Added a separate PurchaseOptionId field on Product and ProductStoreDetails for Google Play one-time products (BasePlanId now stays dedicated to subscription base plans).
— Deprecated the Offerings API. Manage paywall products with Remote Configs instead.
<!-- release-notes:end -->
