### PR TITLE
feat: expose InvalidateRemoteConfigsCache, bump sandwich to 7.12.0 (DEV-1236)

### DIFF
--- a/Editor/QonversionDependencies.xml
+++ b/Editor/QonversionDependencies.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="io.qonversion:sandwich:7.11.0" />
+        <androidPackage spec="io.qonversion:sandwich:7.12.0" />
         <androidPackage spec="com.fasterxml.jackson.core:jackson-databind:2.11.1" />
         <androidPackage spec="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.61" />
     </androidPackages>
     <iosPods>
-      <iosPod name="QonversionSandwich" version="7.11.0" />
+      <iosPod name="QonversionSandwich" version="7.12.0" />
     </iosPods>
 </dependencies>

--- a/Runtime/Android/Plugins/com/qonversion/unitywrapper/QonversionWrapper.java
+++ b/Runtime/Android/Plugins/com/qonversion/unitywrapper/QonversionWrapper.java
@@ -82,6 +82,10 @@ public class QonversionWrapper {
         qonversionSandwich.syncHistoricalData();
     }
 
+    public static synchronized void invalidateRemoteConfigsCache() {
+        qonversionSandwich.invalidateRemoteConfigsCache();
+    }
+
     public static synchronized void syncPurchases() {
         qonversionSandwich.syncPurchases();
     }

--- a/Runtime/Android/QonversionWrapperAndroid.cs
+++ b/Runtime/Android/QonversionWrapperAndroid.cs
@@ -27,6 +27,11 @@ namespace QonversionUnity
             CallQonversion("syncHistoricalData");
         }
 
+        public void InvalidateRemoteConfigsCache()
+        {
+            CallQonversion("invalidateRemoteConfigsCache");
+        }
+
         public void SyncStoreKit2Purchases()
         {
         }

--- a/Runtime/Scripts/IQonversion.cs
+++ b/Runtime/Scripts/IQonversion.cs
@@ -128,7 +128,7 @@ namespace QonversionUnity
         public void RemoteConfigList(string[] contextKeys, bool includeEmptyContextKey, Qonversion.OnRemoteConfigListReceived callback);
 
         /// <summary>
-        /// Invalidates the cache of remote configs so the next <see cref="RemoteConfig"/> or
+        /// Invalidates the cache of remote configs so the next <see cref="RemoteConfig(Qonversion.OnRemoteConfigReceived)"/> or
         /// <see cref="RemoteConfigList(Qonversion.OnRemoteConfigListReceived)"/> call fetches
         /// a fresh targeting evaluation from the server instead of returning the cached copy.
         /// </summary>
@@ -144,7 +144,7 @@ namespace QonversionUnity
         /// Call it when the targeting inputs changed and you need the change
         /// reflected immediately, for example after setting a batch of user
         /// properties your remote config targeting depends on. You do NOT need
-        /// to call it after <see cref="Identify"/> — the SDK invalidates the
+        /// to call it after <see cref="Identify(string)"/> — the SDK invalidates the
         /// cache on identity changes automatically. Call it after
         /// <see cref="Qonversion.Initialize"/>: calling before initialization
         /// throws.

--- a/Runtime/Scripts/IQonversion.cs
+++ b/Runtime/Scripts/IQonversion.cs
@@ -128,6 +128,26 @@ namespace QonversionUnity
         public void RemoteConfigList(string[] contextKeys, bool includeEmptyContextKey, Qonversion.OnRemoteConfigListReceived callback);
 
         /// <summary>
+        /// Invalidates the cache of remote configs so the next RemoteConfig or
+        /// RemoteConfigList call fetches a fresh targeting evaluation from the
+        /// server instead of returning the cached copy.
+        ///
+        /// This method performs no network request itself — it only marks the
+        /// cached values as stale. An in-flight RemoteConfig load is re-issued
+        /// once so its waiting callbacks receive a fresh evaluation; an
+        /// in-flight RemoteConfigList completes with the evaluation it started
+        /// with.
+        ///
+        /// Call it when the targeting inputs changed and you need the change
+        /// reflected immediately, for example after setting a batch of user
+        /// properties your remote config targeting depends on. You do NOT need
+        /// to call it after Identify — the SDK invalidates the cache on
+        /// identity changes automatically. Call it after initialization.
+        /// </summary>
+        /// <see href="https://documentation.qonversion.io/docs/remote-config">Remote Configs</see>
+        public void InvalidateRemoteConfigsCache();
+
+        /// <summary>
         /// This function should be used for the test purposes only. Do not forget to delete the usage of this function before the release.
         /// Use this function to attach the user to the experiment.
         /// </summary>

--- a/Runtime/Scripts/IQonversion.cs
+++ b/Runtime/Scripts/IQonversion.cs
@@ -128,22 +128,27 @@ namespace QonversionUnity
         public void RemoteConfigList(string[] contextKeys, bool includeEmptyContextKey, Qonversion.OnRemoteConfigListReceived callback);
 
         /// <summary>
-        /// Invalidates the cache of remote configs so the next RemoteConfig or
-        /// RemoteConfigList call fetches a fresh targeting evaluation from the
-        /// server instead of returning the cached copy.
-        ///
+        /// Invalidates the cache of remote configs so the next <see cref="RemoteConfig"/> or
+        /// <see cref="RemoteConfigList(Qonversion.OnRemoteConfigListReceived)"/> call fetches
+        /// a fresh targeting evaluation from the server instead of returning the cached copy.
+        /// </summary>
+        /// <remarks>
         /// This method performs no network request itself — it only marks the
         /// cached values as stale. An in-flight RemoteConfig load is re-issued
         /// once so its waiting callbacks receive a fresh evaluation; an
         /// in-flight RemoteConfigList completes with the evaluation it started
-        /// with.
+        /// with. If the re-issued load fails, the previously received evaluation
+        /// is delivered instead of an error — the call never degrades below the
+        /// pre-invalidation result.
         ///
         /// Call it when the targeting inputs changed and you need the change
         /// reflected immediately, for example after setting a batch of user
         /// properties your remote config targeting depends on. You do NOT need
-        /// to call it after Identify — the SDK invalidates the cache on
-        /// identity changes automatically. Call it after initialization.
-        /// </summary>
+        /// to call it after <see cref="Identify"/> — the SDK invalidates the
+        /// cache on identity changes automatically. Call it after
+        /// <see cref="Qonversion.Initialize"/>: calling before initialization
+        /// throws.
+        /// </remarks>
         /// <see href="https://documentation.qonversion.io/docs/remote-config">Remote Configs</see>
         public void InvalidateRemoteConfigsCache();
 

--- a/Runtime/Scripts/Internal/QonversionInternal.cs
+++ b/Runtime/Scripts/Internal/QonversionInternal.cs
@@ -213,6 +213,12 @@ namespace QonversionUnity
             instance.RemoteConfigList(contextKeysJson, includeEmptyContextKey, OnRemoteConfigListForContextKeysMethodName);
         }
 
+        public void InvalidateRemoteConfigsCache()
+        {
+            var instance = GetNativeWrapper();
+            instance.InvalidateRemoteConfigsCache();
+        }
+
         public void AttachUserToExperiment(string experimentId, string groupId, Qonversion.OnAttachUserResponseReceived callback)
         {
             AttachUserCallback = callback;

--- a/Runtime/Scripts/Internal/QonversionInternal.cs
+++ b/Runtime/Scripts/Internal/QonversionInternal.cs
@@ -215,7 +215,7 @@ namespace QonversionUnity
 
         public void InvalidateRemoteConfigsCache()
         {
-            var instance = GetNativeWrapper();
+            IQonversionWrapper instance = GetNativeWrapper();
             instance.InvalidateRemoteConfigsCache();
         }
 

--- a/Runtime/Scripts/Internal/wrappers/qonversion/IQonversionWrapper.cs
+++ b/Runtime/Scripts/Internal/wrappers/qonversion/IQonversionWrapper.cs
@@ -26,6 +26,7 @@ namespace QonversionUnity
         void RemoteConfig([CanBeNull] string contextKey, string callbackName);
         void RemoteConfigList(string callbackName);
         void RemoteConfigList(string contextKeysJson, bool includeEmptyContextKey, string callbackName);
+        void InvalidateRemoteConfigsCache();
         void AttachUserToExperiment(string experimentId, string groupId, string callbackName);
         void DetachUserFromExperiment(string experimentId, string callbackName);
         void AttachUserToRemoteConfiguration(string remoteConfigurationId, string callbackName);

--- a/Runtime/Scripts/Internal/wrappers/qonversion/QonversionWrapperNoop.cs
+++ b/Runtime/Scripts/Internal/wrappers/qonversion/QonversionWrapperNoop.cs
@@ -83,6 +83,10 @@ namespace QonversionUnity
         {
         }
 
+        public void InvalidateRemoteConfigsCache()
+        {
+        }
+
         public void AttachUserToExperiment(string experimentId, string groupId, string callbackName)
         {
         }

--- a/Runtime/iOS/Plugins/QonversionBridge.m
+++ b/Runtime/iOS/Plugins/QonversionBridge.m
@@ -58,6 +58,10 @@ void _syncHistoricalData() {
     [qonversionSandwich syncHistoricalData];
 }
 
+void _invalidateRemoteConfigsCache() {
+    [qonversionSandwich invalidateRemoteConfigsCache];
+}
+
 void _syncStoreKit2Purchases() {
     [qonversionSandwich syncStoreKit2Purchases];
 }

--- a/Runtime/iOS/QonversionWrapperIOS.cs
+++ b/Runtime/iOS/QonversionWrapperIOS.cs
@@ -28,6 +28,9 @@ namespace QonversionUnity
         private static extern void _syncHistoricalData();
 
         [DllImport("__Internal")]
+        private static extern void _invalidateRemoteConfigsCache();
+
+        [DllImport("__Internal")]
         private static extern void _syncStoreKit2Purchases();
 
         [DllImport("__Internal")]
@@ -153,6 +156,13 @@ namespace QonversionUnity
         {
 #if UNITY_IOS
             _syncHistoricalData();
+#endif
+        }
+
+        public void InvalidateRemoteConfigsCache()
+        {
+#if UNITY_IOS
+            _invalidateRemoteConfigsCache();
 #endif
         }
 


### PR DESCRIPTION
B4 exposure from the Remote Config targeting review ([dash-mono PR #674](https://github.com/qonversion/dash-mono/pull/674)). Linear: [DEV-1236](https://linear.app/qonversion/issue/DEV-1236). Exposes the new cache invalidation API released in [android-sdk 9.7.0](https://github.com/qonversion/android-sdk/releases/tag/sdk%2F9.7.0) / [qonversion-ios-sdk 6.14.0](https://github.com/qonversion/qonversion-ios-sdk/releases/tag/6.14.0), bridged by [sandwich 7.12.0](https://github.com/qonversion/sandwich-sdk/releases/tag/7.12.0).

## What changed

1. **Sandwich pinned to 7.12.0** (Android + iOS). Note: the sandwich pod pins `Qonversion` exactly, so apps that also declare the native `Qonversion` pod directly must move to 6.14.0.
2. **New public API `InvalidateRemoteConfigsCache`** — a void no-callback pass-through to the native method. It performs no network request; it marks the remote configs cache stale so the next `RemoteConfig` / `RemoteConfigList` call fetches a fresh targeting evaluation. An in-flight `RemoteConfig` load is re-issued once so its waiting calls receive a fresh evaluation (degrading to the superseded one if the retry fails); an in-flight `RemoteConfigList` completes with the evaluation it started with. You do NOT need to call it after `Identify` — the SDK invalidates on identity changes automatically. Call it after initialization: in Unity, `Qonversion.GetSharedInstance()` throws before `Initialize` on both platforms, so the method is unreachable pre-init.

## Release notes for this wrapper (minor bump)
- Source-breaking note for the release: `IQonversion` (and `IQonversionWrapper` internally) gained a new required member — custom implementations and hand-written mocks must add `InvalidateRemoteConfigsCache`.


- New: `InvalidateRemoteConfigsCache` — invalidate the remote configs cache on demand (e.g. after setting a batch of user properties your targeting depends on).
- Native SDKs updated: Android 9.7.0, iOS 6.14.0 — automatic remote configs cache invalidation on same-uid `identify`, never-worse re-issue of superseded in-flight loads, uncached bundled fallbacks with rate-limit tolerance (remote configs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4V5cx2SMU4VrfPntwfKJ9
