### PR TITLE
Release 9.9.0

### DIFF
--- a/Runtime/Scripts/Internal/QonversionInternal.cs
+++ b/Runtime/Scripts/Internal/QonversionInternal.cs
@@ -28,7 +28,7 @@ namespace QonversionUnity
         private const string OnIsFallbackFileAccessibleMethodName = "OnIsFallbackFileAccessible";
         private const string OnPromotionalOfferMethodName = "OnPromotionalOffer";
 
-        private const string SdkVersion = "9.8.0";
+        private const string SdkVersion = "9.9.0";
         private const string SdkSource = "unity";
 
         private const string DefaultRemoteConfigContextKey = "";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.qonversion.unity",
 	"displayName": "Qonversion",
-	"version": "9.8.0",
+	"version": "9.9.0",
 	"unity": "2018.3",
 	"description": "Empower your mobile app marketing and product decisions with precise subscription data.",
 	"author": {


### PR DESCRIPTION
Release PR

<!-- release-notes:start -->
## New

* New public API `InvalidateRemoteConfigsCache` — invalidates the remote configs cache so the next `RemoteConfig` / `RemoteConfigList` call fetches a fresh targeting evaluation. It performs no network request itself; call it when the targeting inputs changed and you need the change reflected immediately, for example after setting a batch of user properties your targeting depends on. You do not need to call it after `Identify` — the SDK invalidates the cache on identity changes automatically (#326).

## Improvements & fixes

* Native SDKs updated via QonversionSandwich 7.12.0: [Android 9.7.0](https://github.com/qonversion/android-sdk/releases/tag/sdk%2F9.7.0) and [iOS 6.14.0](https://github.com/qonversion/qonversion-ios-sdk/releases/tag/6.14.0) — automatic remote configs cache invalidation on same-uid `Identify`, never-worse re-issue of superseded in-flight remote config loads, uncached bundled fallbacks with rate-limit tolerance (remote configs only) (#326).

## Breaking notes

* `IQonversion` gained a new required member — custom implementations and hand-written mocks must add `InvalidateRemoteConfigsCache`.
* The sandwich pod pins the native `Qonversion` pod exactly: apps that also declare `Qonversion` directly must move to 6.14.0.
<!-- release-notes:end -->
