### PR TITLE
feat: expose frozen Remote Config assignments

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,20 @@
+name: Checks
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bridge-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Verify frozen assignment contract
+        run: node scripts/test-frozen-assignment-contract.mjs

--- a/Editor/QonversionDependencies.xml
+++ b/Editor/QonversionDependencies.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="io.qonversion:sandwich:7.12.0" />
+        <androidPackage spec="io.qonversion:sandwich:7.13.0" />
         <androidPackage spec="com.fasterxml.jackson.core:jackson-databind:2.11.1" />
         <androidPackage spec="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.61" />
     </androidPackages>
     <iosPods>
-      <iosPod name="QonversionSandwich" version="7.12.0" />
+      <iosPod name="QonversionSandwich" version="7.13.0" />
     </iosPods>
 </dependencies>

--- a/Runtime/Scripts/Dto/RemoteConfigurationSource.cs
+++ b/Runtime/Scripts/Dto/RemoteConfigurationSource.cs
@@ -33,6 +33,10 @@ namespace QonversionUnity
             {
                 return RemoteConfigurationAssignmentType.Manual;
             }
+            else if (type == "frozen")
+            {
+                return RemoteConfigurationAssignmentType.Frozen;
+            }
 
             return RemoteConfigurationAssignmentType.Unknown;
         }
@@ -70,7 +74,8 @@ namespace QonversionUnity
     {
         Unknown,
         Auto,
-        Manual
+        Manual,
+        Frozen
     }
 
     public enum RemoteConfigurationSourceType

--- a/scripts/test-frozen-assignment-contract.mjs
+++ b/scripts/test-frozen-assignment-contract.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync("Runtime/Scripts/Dto/RemoteConfigurationSource.cs", "utf8");
+const dependencies = readFileSync("Editor/QonversionDependencies.xml", "utf8");
+
+assert.match(source, /type\s*==\s*"frozen"[\s\S]*RemoteConfigurationAssignmentType\.Frozen/);
+assert.match(source, /return\s+RemoteConfigurationAssignmentType\.Unknown/);
+assert.match(source, /enum\s+RemoteConfigurationAssignmentType[\s\S]*Frozen/);
+assert.match(dependencies, /io\.qonversion:sandwich:7\.13\.0/);
+assert.match(dependencies, /QonversionSandwich" version="7\.13\.0"/);
+
+console.log("Frozen assignment bridge contract is intact.");


### PR DESCRIPTION
Adds `frozen` assignment provenance to Unity and pins both native Sandwich packages to 7.13.0. Draft/stacked: merge only after qonversion/sandwich-sdk#357 is published. A static Frozen/Unknown/native-dependency contract now runs in pull-request CI. The contract and actionlint pass locally; Unity compilation remains a release-side check.
